### PR TITLE
[feat] Syntax Highlighting

### DIFF
--- a/convert/scripts/convert.py
+++ b/convert/scripts/convert.py
@@ -235,7 +235,7 @@ _p_pre_code_close = r"[\s\r\n]*</code>[\s\r\n]*</pre>"
 p_pre_code_open = re.compile(_p_pre_code_open, re.MULTILINE)
 p_pre_code_close = re.compile(_p_pre_code_close, re.MULTILINE)
 p_syntax_highlighting = re.compile(r"^```(.+)$", re.MULTILINE)
-p_hidden_links = re.compile(r"^\s*<a [\>]* aria-hidden=\"true\"\s?/>\s*\n", re.MULTILINE)
+p_hidden_links = re.compile(r'<a href="#gitlab[^>]*" aria-hidden="true"></a>', re.MULTILINE)
 
 def _fix_code_blocks(html: str) -> str:
 	html = re.sub(p_pre_code_open, "<pre><code>", html)

--- a/convert/scripts/convert.py
+++ b/convert/scripts/convert.py
@@ -230,10 +230,8 @@ def to_prettyxml(doc):
 	output = re.sub(r"\n*$", "\n", output)
 	return output
 
-_p_pre_code_open = r"<pre>[\s\r\n]*<code>[\s\r\n]*"
-_p_pre_code_close = r"[\s\r\n]*</code>[\s\r\n]*</pre>"
-p_pre_code_open = re.compile(_p_pre_code_open, re.MULTILINE)
-p_pre_code_close = re.compile(_p_pre_code_close, re.MULTILINE)
+p_pre_code_open = re.compile(r"<pre>[\s\r\n]*<code>[\s\r\n]*", re.MULTILINE)
+p_pre_code_close = re.compile(r"[\s\r\n]*</code>[\s\r\n]*</pre>", re.MULTILINE)
 p_syntax_highlighting = re.compile(r"^```(.+)$", re.MULTILINE)
 p_hidden_links = re.compile(r'<a href="#gitlab[^>]*" aria-hidden="true"></a>', re.MULTILINE)
 

--- a/convert/scripts/entrypoint.sh
+++ b/convert/scripts/entrypoint.sh
@@ -10,6 +10,10 @@ if [ "${INCLUDE_LABELS}" != "" ]; then
 	EXTRA_ARGS="$EXTRA_ARGS --include-labels"
 fi
 
+if [ "${HIGHLIGHT_SYNTAX}" != "" ]; then
+	EXTRA_ARGS="$EXTRA_ARGS --highlight-syntax"
+fi
+
 set -e
 set -x
 python3 ${PYTHON_ARGS} /scripts/convert.py ${EXTRA_ARGS}


### PR DESCRIPTION
Syntax Highlighting can be enabled with `--highlight-syntax` or `HIGHLIGHT_SYNTAX=yes` environment variable and is disabled by default to stay backwards compatible with existing projects.

Incorporates GPL-compliant source code from Cpython: https://github.com/python/cpython/blob/bfc57d43d8766120ba0c8f3f6d7b2ac681a81d8a/Lib/xml/etree/ElementTree.py#L1140-L1187

This modified indent method allows us to exclude `<pre>` elements from indentation. Otherwise preserved whitespace adds unnecessary left padding to code block elements within a PDF report.