### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @radicallyopensecurity/pentext


### PR DESCRIPTION
Add CODEOWNERS so that Pentext team members need to approve changes.