### PR TITLE
Fix GitLab upload path

### DIFF
--- a/convert/scripts/convert.py
+++ b/convert/scripts/convert.py
@@ -369,7 +369,11 @@ class Upload:
 		dirname = os.path.dirname(self.local_path)
 		os.makedirs(dirname, exist_ok=True)
 		logging.info(f"downloading {self.url} to {self.local_path}")
-		urllib.request.urlretrieve(self.url, self.local_path)
+		try:
+			urllib.request.urlretrieve(self.url, self.local_path)
+		except Exception as err:
+			print("download failed")
+			raise err
 
 
 class PentextXMLFile:

--- a/convert/scripts/convert.py
+++ b/convert/scripts/convert.py
@@ -354,7 +354,7 @@ class Upload:
 	def url(self):
 		project_url = urllib.parse.urljoin(
 			client._base_url,
-			self.pentext_project.path_with_namespace
+			f"-/project/{self.pentext_project.id}"
 		)
 		return f"{project_url}{self.path}"
 	


### PR DESCRIPTION
Downloads failed silently. Apparently the GitLab project URL pattern changed and now enforces `/-/project/<ID>/` prefix. This and a tiny error message is added by this PR that makes it easier to debug similar issues in the future. URLs can change.

<img width="1049" alt="image" src="https://github.com/user-attachments/assets/ab3eb921-f483-4108-903d-25a626539969">

```
Executing "step_script" stage of the job script
Using docker image sha256:7d0e7f3969feeb8a1c7fd13887feefaf358ef1f997dd162870b3324a61982f98 for convert ...
+ python3 /scripts/convert.py
INFO:root:parsing source/report.xml
INFO:root:downloading https://git.radicallyopensecurity.com/playground/test-gitlab-api-bug/uploads/6d5e193cad3aa4ebab430dbfd90a7c02/image.png to uploads/6d5e193cad3aa4ebab430dbfd90a7c02/image.png
ERROR:root:failed to obtain XML content of findings/f2-not-okay-finding.xml
INFO:root:writing findings/f1-okay-finding.xml
WARNING:root:Non-findings section does not exist in report.xml
INFO:root:Reading Conclusion from source/conclusion.xml
INFO:root:writing source/conclusion.xml
INFO:root:Reading Results In A Nutshell from source/resultsinanutshell.xml
INFO:root:writing source/resultsinanutshell.xml
INFO:root:Reading Future Work from source/futurework.xml
INFO:root:writing source/futurework.xml
INFO:root:writing source/report.xml
INFO:root:ROS Project written
INFO:root:writing ./target/junit.xml
+ find uploads -type f -exec python3 /scripts/sanitize-acropalypse.py {} ;
Uploading artifacts for successful job
Uploading artifacts...
```

Notice the error assembling the XML for finding 2, which unlike finding 1 contains an image in this test case. This leads to the finding XML file not being written, but linked in `report.xml`, consequently causing an error in docbuilder.