### PR TITLE
fix regex escape by using double backslash

### DIFF
--- a/convert/scripts/convert.py
+++ b/convert/scripts/convert.py
@@ -331,7 +331,7 @@ def _is_pentext_label(label) -> bool:
 class Upload:
 
 	upload_path_pattern = re.compile(
-		"(?:\.{2})?/uploads/(?P<hex>[A-Fa-f0-9]{32})/(?P<filename>[^\.][^/]+)"
+		"(?:\\.{2})?/uploads/(?P<hex>[A-Fa-f0-9]{32})/(?P<filename>[^\\.][^/]+)"
 	)
 
 	def __init__(self, path, pentext_project=None) -> None:


### PR DESCRIPTION
The following warning occurs when converting GitLab issues to Pentext XML:

```
/scripts/convert.py:335: SyntaxWarning: invalid escape sequence '\.' 
```

Fixing this issue by escaping with double backslash.