### PR TITLE
[feat] Report Variants

### DIFF
--- a/docbuilder/Dockerfile
+++ b/docbuilder/Dockerfile
@@ -1,7 +1,7 @@
 ARG FOP_VERSION=2.7
 ARG SAXON_VERSION=10.5
 
-FROM eclipse-temurin:20 as download-and-extract-tools
+FROM eclipse-temurin:20 AS download-and-extract-tools
 ARG FOP_VERSION
 ARG SAXON_VERSION
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   convert:
     build:


### PR DESCRIPTION
Allows to tweak docbuilder via env variables, so that multiple report variants can be built.

```sh
docker compose run --rm  \
  -v /path/to/project:/pentext \
  -e "SOURCE_DOCUMENTS=offerte" \
  -e "SOURCE_REPORTS=report-vendor report-ncsc report-customer" \
  docbuilder
```