### PR TITLE
[Hotfix] Pin python-gitlab version 4

### DIFF
--- a/convert/Dockerfile
+++ b/convert/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y python3 python3-pip python3-tz python3-venv pandoc
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN python3 -m pip install pypandoc python-gitlab python-slugify
+RUN python3 -m pip install pypandoc "python-gitlab==4.13.0" python-slugify
 
 # ADD scripts/gitlab_to_pentext.py /scripts/gitlab_to_pentext.py
 # ADD scripts/gl2pentext_postprocess.py /scripts/gl2pentext_postprocess.py


### PR DESCRIPTION
Changes in python-gitlab 5.0.0 break with the convert script. To temporary allow continuous use of the latest 4 major release version the version is pinned in Dockerfile.