### PR TITLE
[chore] Don't expose Docker auth-proxy on loopback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,6 @@ services:
       context: ./proxy
     expose:
       - 80
-    ports:
-      - "127.0.0.1:80:80"
     environment:
       CI_SERVER_URL: "${CI_SERVER_URL}"
       EXTRA_COOKIES: "${EXTRA_COOKIES}"


### PR DESCRIPTION
When performing API queries through the Docker proxy service, the convert runner can directly access the network and does not need it exposed on the host.