### PR TITLE
[fix] manually filter labels for part-sections

### DIFF
--- a/convert/scripts/convert.py
+++ b/convert/scripts/convert.py
@@ -1373,7 +1373,7 @@ class PentextProject(gitlab.v4.objects.projects.Project):
 		}
 		issues = self.get_report_assets(
 			SectionPart,
-			labels=[],
+			#labels=[],
 			milestone=None,
 			**kwargs
 		)
@@ -1390,9 +1390,17 @@ class PentextProject(gitlab.v4.objects.projects.Project):
 		return obj_cls(*parts, pentext_project=self)
 
 	def get_report_section_parts_by_labels(self, labels):
-		for issue in self.get_report_assets(SectionPart, labels=labels, milestone=None):
-			if self._match_milestone_and_labels(issue):
-				yield issue
+		issues = self.get_report_assets(
+			SectionPart,
+			#labels=labels,
+			milestone=None
+		)
+		for issue in issues:
+			if not self._match_milestone_and_labels(issue):
+				continue
+			if not self._match_labels(issue.labels, [labels]):
+				continue
+			yield issue
 
 	def get_report_section_by_labels(self, labels, obj_cls):
 		parts = [*self.get_report_section_parts_by_labels(labels)]


### PR DESCRIPTION
Sections like Future Work are converted from multiple GitLab issues. When using multiple custom labels, this conversion can fail.