### PR TITLE
Bump Python-Gitlab to v5.6.0

### DIFF
--- a/convert/Dockerfile
+++ b/convert/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y python3 python3-pip python3-tz python3-venv pandoc
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN python3 -m pip install pypandoc "python-gitlab==4.13.0" python-slugify
+RUN python3 -m pip install pypandoc "python-gitlab==5.6.0" python-slugify
 
 # ADD scripts/gitlab_to_pentext.py /scripts/gitlab_to_pentext.py
 # ADD scripts/gl2pentext_postprocess.py /scripts/gl2pentext_postprocess.py


### PR DESCRIPTION
v4.13.0 is from 2024-10-08, and so may fall out of sync with future Gitlab versions. v5.6.0 works in my testing