### PR TITLE
Update versions of OS, Saxon and FOP

### DIFF
--- a/docbuilder/Dockerfile
+++ b/docbuilder/Dockerfile
@@ -1,7 +1,9 @@
-ARG FOP_VERSION=2.7
-ARG SAXON_VERSION=10.5
+ARG FOP_VERSION=2.11
+# there are newer 11.x and 12.x Saxon versions available
+ARG SAXON_VERSION=10.9
 
-FROM eclipse-temurin:20 AS download-and-extract-tools
+# eclipse-temurin:21 tracks JDK 21, which is LTS
+FROM eclipse-temurin:21 AS download-and-extract-tools
 ARG FOP_VERSION
 ARG SAXON_VERSION
 

--- a/off2rep/Dockerfile
+++ b/off2rep/Dockerfile
@@ -1,13 +1,15 @@
-ARG SAXON_VERSION=10.3
+# there are newer 11.x and 12.x Saxon versions available
+ARG SAXON_VERSION=10.9
 
-FROM eclipse-temurin:20-alpine as download-and-extract-tools
+# eclipse-temurin:21 tracks JDK 21, which is LTS
+FROM eclipse-temurin:21-alpine as download-and-extract-tools
 ARG SAXON_VERSION
 
 RUN wget https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
 # use strict to force error exit code when jar is unsigned
 RUN jarsigner -verify -strict Saxon-HE-${SAXON_VERSION}.jar
 
-FROM eclipse-temurin:20-alpine
+FROM eclipse-temurin:21-alpine
 ARG SAXON_VERSION
 
 COPY --from=download-and-extract-tools /Saxon-HE-${SAXON_VERSION}.jar /saxon.jar

--- a/quickscope/Dockerfile
+++ b/quickscope/Dockerfile
@@ -1,13 +1,15 @@
-ARG SAXON_VERSION=10.3
+# there are newer 11.x and 12.x Saxon versions available
+ARG SAXON_VERSION=10.9
 
-FROM eclipse-temurin:20-alpine as download-and-extract-tools
+# eclipse-temurin:21 tracks JDK 21, which is LTS
+FROM eclipse-temurin:21-alpine as download-and-extract-tools
 ARG SAXON_VERSION
 
 RUN wget https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
 # use strict to force error exit code when jar is unsigned
 RUN jarsigner -verify -strict Saxon-HE-${SAXON_VERSION}.jar
 
-FROM eclipse-temurin:20-alpine
+FROM eclipse-temurin:21-alpine
 ARG SAXON_VERSION
 
 COPY --from=download-and-extract-tools /Saxon-HE-${SAXON_VERSION}.jar /saxon.jar


### PR DESCRIPTION
Update software versions in the container files.

Note that there are newer major versions `11.x` and `12.x` of Saxon available, and https://www.saxonica.com/html/products/latest.html suggests that `10.x` is no longer among the version ranges that receives maintenance. I think we should do these major version changes for Saxon separately.

The switch to `eclipse-temurin` version `21` is motivated by the fact that JDK `21` is a long-term-support version, and that version 20 is end-of-life by now, see [Oracle's support table](https://www.oracle.com/java/technologies/java-se-support-roadmap.html).

Limited local testing via `podman build`. Please test separately against runtime regressions.
